### PR TITLE
Update Glowing Bear URLs to own domain

### DIFF
--- a/weechat/templates/about/features.html
+++ b/weechat/templates/about/features.html
@@ -140,7 +140,7 @@
           &mdash; Emacs
         </li>
         <li>
-          <a href="https://glowing-bear.github.io/glowing-bear/" target="_blank">glowing-bear <img src="{{ MEDIA_URL }}images/link.png" alt="" /></a>
+          <a href="http://www.glowing-bear.org" target="_blank">Glowing Bear <img src="{{ MEDIA_URL }}images/link.png" alt="" /></a>
           &mdash; HTML5
         </li>
         <li>

--- a/weechat/templates/download/packages.html
+++ b/weechat/templates/download/packages.html
@@ -135,7 +135,7 @@
         <div class="dlitem">
           <span class="dltype">HTML5</span>
           <img src="{{ MEDIA_URL }}images/dl_html5.png" class="dlicon" alt="html5" />
-          <a href="https://glowing-bear.github.io/glowing-bear/" target="_blank">https://glowing-bear.github.io/glowing-bear/</a>
+          <a href="http://www.glowing-bear.org" target="_blank">http://www.glowing-bear.org/</a>
           <img src="{{ MEDIA_URL }}images/link.png" class="dllink" alt="" />
         </div>
         <div class="dlitem">


### PR DESCRIPTION
Glowing Bear is now hosted at http://www.glowing-bear.org - we have our own domain! \o/

current master branch is also deployed at https://latest.glowing-bear.org but I don't think this is relevant here, as master is a bit unstable/broken at times
