### PR TITLE
debian download: use apt-get instead of aptitude

### DIFF
--- a/weechat/templates/download/debian.html
+++ b/weechat/templates/download/debian.html
@@ -110,11 +110,11 @@ var deb_apt_cmds = [
     <ul>
       <li>
         {% blocktrans %}You must use apt, apt-get or aptitude to install the packages (with sudo or as "root" user).{% endblocktrans %}
-        <br />{% trans "The following examples use sudo and aptitude." %}
+        <br />{% trans "The following examples use sudo and apt-get." %}
       </li>
       <li>
         {% trans "Install https transport for apt:" %}
-        <kbd>$ sudo aptitude install apt-transport-https</kbd>
+        <kbd>$ sudo apt-get install apt-transport-https</kbd>
         {% blocktrans %}Otherwise you can replace "https://" by "http://" in URLs (less secure).{% endblocktrans %}
       </li>
       <li>
@@ -133,18 +133,18 @@ var deb_apt_cmds = [
       </li>
       <li>
         {% trans "Resynchronize your package index files:" %}
-        <kbd>$ sudo aptitude update</kbd>
+        <kbd>$ sudo apt-get update</kbd>
       </li>
       <li>
         {% blocktrans %}Install the binary packages; the "plugins" package is highly recommended but not mandatory.{% endblocktrans %}
         <ul>
           <li>
             {% trans "For the stable version:" %}
-            <kbd>$ sudo aptitude install weechat-curses weechat-plugins</kbd>
+            <kbd>$ sudo apt-get install weechat-curses weechat-plugins</kbd>
           </li>
           <li>
             {% trans "For the development version:" %}
-            <kbd>$ sudo aptitude install weechat-devel-curses weechat-devel-plugins</kbd>
+            <kbd>$ sudo apt-get install weechat-devel-curses weechat-devel-plugins</kbd>
           </li>
         </ul>
       </li>


### PR DESCRIPTION
Whether aptitude is installed by default or not varies a lot by
distribution and distribution version and same with is it recommended or
discouraged.

apt-get is the only one which is surely in all Debian-based
distributions and versions by default. apt would work too, but it was
added in apt 1.0 and I don't think it was in oldoldstable which is still
supported.