### PR TITLE
repos: use pool.sks-keyservers.net as keyserver

### DIFF
--- a/weechat/templates/download/debian.html
+++ b/weechat/templates/download/debian.html
@@ -126,7 +126,7 @@ var deb_apt_cmds = [
       </li>
       <li>
         {% trans "Import the gpg key used to sign the repository:" %}
-        <kbd>$ sudo apt-key adv --keyserver keys.gnupg.net --recv-keys 11E9DE8848F2B65222AA75B8D1820DB22A11534E</kbd>
+        <kbd>$ sudo apt-key adv --keyserver pool.sks-keyservers.net --recv-keys 11E9DE8848F2B65222AA75B8D1820DB22A11534E</kbd>
       </li>
       <li>
         {% trans "Create a weechat.list file with the repository, according to your distribution/version:" %}

--- a/weechat/templates/download/packages.html
+++ b/weechat/templates/download/packages.html
@@ -153,7 +153,7 @@
         <ul>
           <li>
             {% trans "Import the gpg key:" %}
-            <br /><kbd>$ gpg --keyserver keys.gnupg.net --recv-keys A9AB5AB778FA5C3522FD0378F82F4B16DEC408F8</kbd>
+            <br /><kbd>$ gpg --keyserver pool.sks-keyservers.net --recv-keys A9AB5AB778FA5C3522FD0378F82F4B16DEC408F8</kbd>
           </li>
           <li>
             {% trans "Display the fingerprint:" %}


### PR DESCRIPTION
```
2016-03-13 11:54:09+0200 < Halbard> When signing the repository,
keyserver keys.gnupg.net is apparently not working, I was unable to
import the key for days until I tried with another server.
```

However afterwards I noticed `keys.gnupg.net` is an alias for `pool.sks-keyservers.net`, but thought that I would commit this anyway in case using pool.sks-keyservers.net directly instead of via CNAME is considered as better.