### PR TITLE
Fix missing ADMIN_PAGE in installation

### DIFF
--- a/weechat/settings_local.template
+++ b/weechat/settings_local.template
@@ -36,6 +36,7 @@ if PRODUCTION:
 
     ADMINS = (('root', 'root@localhost'),)
     MANAGERS = ADMINS
+    ADMIN_PAGE = 'admin'
 
     # These recipients will receive new/updated scripts by e-mail.
     SCRIPTS_MAILTO = ['root <root@localhost>']
@@ -72,6 +73,7 @@ else:
 
     ADMINS = ()
     MANAGERS = ADMINS
+    ADMIN_PAGE = 'admin'
 
     # These recipients will receive new/updated scripts by e-mail.
     SCRIPTS_MAILTO = ['root <root@localhost>']


### PR DESCRIPTION
```
$ ./bin/install.sh

--- Copy settings_local.template to settings_local.py
'./weechat/settings_local.template' -> './weechat/settings_local.py'

--- Change settings in settings_local.py (like database)? (Y/n) y

--- Compiling messages
processing file django.po in weechat/locale/ja/LC_MESSAGES
processing file django.po in weechat/locale/fr/LC_MESSAGES
processing file django.po in weechat/locale/de/LC_MESSAGES
processing file django.po in weechat/locale/it/LC_MESSAGES
processing file django.po in weechat/locale/pt_BR/LC_MESSAGES
processing file django.po in weechat/locale/pl/LC_MESSAGES

--- Creating database
Traceback (most recent call last):
  File "./manage.py", line 30, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/lib/python3.7/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
    utility.execute()
  File "/usr/lib/python3.7/site-packages/django/core/management/__init__.py", line 375, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/lib/python3.7/site-packages/django/core/management/base.py", line 316, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/lib/python3.7/site-packages/django/core/management/base.py", line 350, in execute
    self.check()
  File "/usr/lib/python3.7/site-packages/django/core/management/base.py", line 379, in check
    include_deployment_checks=include_deployment_checks,
  File "/usr/lib/python3.7/site-packages/django/core/management/commands/migrate.py", line 60, in _run_checks
    issues.extend(super()._run_checks(**kwargs))
  File "/usr/lib/python3.7/site-packages/django/core/management/base.py", line 366, in _run_checks
    return checks.run_checks(**kwargs)
  File "/usr/lib/python3.7/site-packages/django/core/checks/registry.py", line 71, in run_checks
    new_errors = check(app_configs=app_configs)
  File "/usr/lib/python3.7/site-packages/django/core/checks/urls.py", line 13, in check_url_config
    return check_resolver(resolver)
  File "/usr/lib/python3.7/site-packages/django/core/checks/urls.py", line 23, in check_resolver
    return check_method()
  File "/usr/lib/python3.7/site-packages/django/urls/resolvers.py", line 396, in check
    for pattern in self.url_patterns:
  File "/usr/lib/python3.7/site-packages/django/utils/functional.py", line 37, in __get__
    res = instance.__dict__[self.name] = self.func(instance)
  File "/usr/lib/python3.7/site-packages/django/urls/resolvers.py", line 533, in url_patterns
    patterns = getattr(self.urlconf_module, "urlpatterns", self.urlconf_module)
  File "/usr/lib/python3.7/site-packages/django/utils/functional.py", line 37, in __get__
    res = instance.__dict__[self.name] = self.func(instance)
  File "/usr/lib/python3.7/site-packages/django/urls/resolvers.py", line 526, in urlconf_module
    return import_module(self.urlconf_name)
  File "/usr/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "weechat/urls.py", line 46, in <module>
    url(r'^%s/doc/' % settings.ADMIN_PAGE,
  File "/usr/lib/python3.7/site-packages/django/conf/__init__.py", line 58, in __getattr__
    val = getattr(self._wrapped, name)
AttributeError: 'Settings' object has no attribute 'ADMIN_PAGE'
```