### PR TITLE
Fix German translation of “scripts”

### DIFF
--- a/weechat/locale/de/LC_MESSAGES/django.po
+++ b/weechat/locale/de/LC_MESSAGES/django.po
@@ -22,7 +22,7 @@ msgstr ""
 "Project-Id-Version: WeeChat.org\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-05-01 11:33+0200\n"
-"PO-Revision-Date: 2020-05-13 16:58+0200\n"
+"PO-Revision-Date: 2020-05-15 10:21+0200\n"
 "Last-Translator: Nils Görs <weechatter@arcor.de>\n"
 "Language-Team: German <kde-i18n-de@kde.org>\n"
 "Language: de\n"
@@ -30,7 +30,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 2.2.4\n"
+"X-Generator: Poedit 2.3\n"
 
 #: about/_i18n_keydates.py:10
 msgid "256 colors, irc proxy, rmodifier, redirection of irc commands."
@@ -139,7 +139,7 @@ msgstr "vererbte Werte bei nicht gesetzten Optionen."
 #: about/_i18n_keydates.py:30
 msgid "Javascript plugin, IRC SASL mechanism \"ecdsa-nist256p-challenge\"."
 msgstr ""
-"Javascript Erweiterung, IRC SASL Mechanismus \"ecdsa-nist256p-challenge\"."
+"Javascript-Erweiterung, IRC-SASL-Mechanismus \"ecdsa-nist256p-challenge\"."
 
 #: about/_i18n_keydates.py:31
 msgid "Last version before a major rewrite of WeeChat."
@@ -177,9 +177,7 @@ msgstr "Erweiterung \"buflist\" (zeigt Buffer in einer separaten Bar an)."
 
 #: about/_i18n_keydates.py:38
 msgid "Plugin \"script\" (scripts manager), SSL in relay."
-msgstr ""
-"\"script\" Erweiterung (Skripten-Manager, ala APT), SSL Unterstützung für "
-"Relay."
+msgstr "\"script\"-Erweiterung (Skriptmanager), SSL-Unterstützung für Relay."
 
 #: about/_i18n_keydates.py:39
 msgid "Proxy support, IPv6, SSL."
@@ -260,7 +258,7 @@ msgstr "Ausgabe von \"git rev-parse HEAD\" für Quelltext Repositorium."
 
 #: dev/views.py:60
 msgid "Output of \"git rev-parse HEAD\" for scripts repository."
-msgstr "Ausgabe von \"git rev-parse HEAD\" für Skripten Repositorium."
+msgstr "Ausgabe von \"git rev-parse HEAD\" für Skriptrepositorium."
 
 #: dev/views.py:65
 msgid "Next stable version."
@@ -401,7 +399,7 @@ msgstr ""
 msgid ""
 "Remove/unload all scripts calling function hook_process (for maximum safety)."
 msgstr ""
-"entferne/beende alle Skripten, die die Funktion hook_process nutzen (dient "
+"entferne/beende alle Skripte, die die Funktion hook_process nutzen (dient "
 "der maximalen Sicherheit)."
 
 #: doc/_i18n_security.py:24
@@ -457,8 +455,8 @@ msgid ""
 msgstr ""
 "nicht vertrauenswürdiger Befehl, für die Funktion hook_process, kann dazu "
 "genutzt werden um Befehle über eine Shell-Erweiterung zu starten (dieses "
-"Problem betrifft nur einige Skripten und ist im engeren Sinne kein Fehler "
-"von WeeChat)."
+"Problem betrifft nur einige Skripte und ist im engeren Sinne kein Fehler von "
+"WeeChat)."
 
 #. Translators: this is a severity level for a security vulnerability
 #: doc/models.py:37 templates/doc/security.html:97
@@ -547,7 +545,7 @@ msgstr "Anleitung für API Erweiterung"
 
 #: doc/models.py:103
 msgid "Scripting guide"
-msgstr "Skript Anleitung"
+msgstr "Skriptanleitung"
 
 #: doc/models.py:104
 msgid "Quick Start guide"
@@ -687,7 +685,7 @@ msgid ""
 "The xz packages are smaller than gzip (~2x) and bzip2 (~1.4x)."
 msgstr ""
 "Alle Quellpakete sind nun auch als xz Pakete verfügbar (als Ergänzung zu "
-"gzip und bzip2): stabile/Entwicklerversion, alte  Versionen, Skripten, "
+"gzip und bzip2): stabile/Entwicklerversion, alte Versionen, Skripte, "
 "QWeeChat.\n"
 "\n"
 "Die xz Pakete sind kleiner gegenüber gzip (~2x) und bzip2 (~1.4x)."
@@ -1028,12 +1026,12 @@ msgid ""
 "\n"
 "More info on the <a href=\"/scripts/python3\">transition page</a>."
 msgstr ""
-"Die Python 3 Portierungs-Party für WeeChat Skripten hat begonnen!\n"
+"Die Python 3 Portierung-Party für WeeChat-Skripte hat begonnen!\n"
 "\n"
-"Es gibt 173 Skripten welche auf Python 3 portiert werden müssen (zur Zeit "
+"Es gibt 173 Skripte welche auf Python 3 portiert werden müssen (zur Zeit "
 "muss dabei aber die Kompatibilität mit Python 2.7 erhalten bleiben).\n"
 "Du kannst uns dabei helfen unser Ziel zu erreichen, dass zu Beginn des "
-"Jahres 2020 alle Skripten Python3-kompatibel sind!\n"
+"Jahres 2020 alle Skripte Python3-kompatibel sind!\n"
 "\n"
 "Weitere Information findest Du auf der <a href=\"/scripts/"
 "python3\">Umstellungsseite</a>."
@@ -1166,7 +1164,7 @@ msgstr ""
 "Version 0.0.4 ist verfügbar!\n"
 "\n"
 "Neuerungen:\n"
-"- Perl Skripten werden unterstützt und automatisch geladen\n"
+"- Perl-Skripte werden unterstützt und automatisch geladen\n"
 "- Highlight\n"
 "- Ctrl-C wird abgefangen (ignoriert)\n"
 "- Debug Mitteilungen können eingeschaltet werden via ./configure --enbale-"
@@ -1189,7 +1187,7 @@ msgstr ""
 "Version 0.0.5 ist verfügbar!\n"
 "\n"
 "Neuerungen:\n"
-"- Info-bar mit Highlights von anderen Channels, kann über Perl-Skript "
+"- Info-bar mit Highlights von anderen Channels, kann über Perl-Skripte "
 "modifiziert werden\n"
 "- /set Befehl (Konfiguration kann während der Laufzeit von WeeChat "
 "konfiguriert werden)\n"
@@ -1530,10 +1528,10 @@ msgstr ""
 "neue Werte für \"irc_display_away\" (off, local, channel)\n"
 "- Texinfo doc ersetzt durch XML Docbook\n"
 "- hinzugefügt: Farbe für Fenstertrenner\n"
-"- hinzugefügt: automatische Vervollständigung für Erweiterung/Skripten "
-"Befehle\n"
+"- hinzugefügt: automatische Vervollständigung für Erweiterungs-/"
+"Skriptebefehle\n"
 "- hinzugefügt: /charset Befehl für Server und Channel\n"
-"- hinzugefügt: Erweiterung für Ruby-Skripten\n"
+"- hinzugefügt: Erweiterung für Ruby-Skripte\n"
 "- hinzugefügt: ETA (Estimated Time of Arrival) für DCC Dateien\n"
 "- /nick command kann auch ausgeführt werden wenn man nicht mit dem Server "
 "verbunden ist\n"
@@ -1592,7 +1590,7 @@ msgstr ""
 "f12} das selbe in der Nicklist\n"
 "- hinzugefügt: neue Tasten zum scrollen einzelner Zeilen (Standard: alt-pgup/"
 "pgdn)\n"
-"- hinzugefügt: Erweiterung für Lua Skripten\n"
+"- hinzugefügt: Erweiterung für Lua-Skripte\n"
 "- verbessert: Ruby Erweiterung\n"
 "- hinzugefügt: Funktionen für API Erweiterung: get_server_info, "
 "free_server_info, get_channel_info, free_channel_info, get_nick_info, "
@@ -1963,7 +1961,7 @@ msgstr ""
 "- SASL Authentifizierung bei IRC Servern,\n"
 "- neue Befehle: mute, map\n"
 "- /key-Befehl wurde überarbeitet,\n"
-"- neue Option beim Programmstart: \"-s\" WeeChat wird ohne Skripten "
+"- neue Option beim Programmstart: \"-s\" WeeChat wird ohne Skripte "
 "gestartet,\n"
 "- laden der Erweiterungen verbessert,\n"
 "- benutzerdefinierte Vervollständigung für Alias,\n"
@@ -2086,7 +2084,7 @@ msgstr ""
 "- Anzahl der Nachrichten wird in der Hotliste für jeden Buffer dargestellt\n"
 "- Buffer von Fenstern tauschen\n"
 "- Größenanpassung von Fenstern\n"
-"- neue API Funktion für Hilfstexte für Erweiterungen/Skripten-Optionen\n"
+"- neue API Funktion für Hilfstexte für Erweiterungs-/Skriptoptionen\n"
 "- Buchstabieroptionen für Aspell-Erweiterung\n"
 "- Optionen für SSL Priorität bei IRC Servern\n"
 "- Nicks werden in der Nickliste und bei der Ausgabe von /names farblich "
@@ -2193,7 +2191,7 @@ msgstr ""
 "sind und ganz neue Funktionen bietet.\n"
 "\n"
 "Zu den neuen Eigenschaften dieser Version:\n"
-"- Unterstützung von Scheme Skripten (neue Erweiterung \"guile\")\n"
+"- Unterstützung von Scheme-Skripten (neue Erweiterung \"guile\")\n"
 "- Unterstützung von Python 3.0 (Version 2.x wird weiterhin empfohlen)\n"
 "- \"weechat\" Protokoll in der Relay-Erweiterung für Remoteschnittstellen "
 "hinzugefügt, z.B. <a href=\"/blog/post/2011/12/25/QWeeChat-Python-Qt-GUI"
@@ -2776,7 +2774,7 @@ msgstr ""
 "\"ssl_fingerprint\"\n"
 "- Unterstützung der IRC capability \"account-notify\"\n"
 "- entfernt: \"freenode\" Server aus der Standardkonfiguration\n"
-"- neue Skriptenerweiterung für javascript\n"
+"- neue Skripterweiterung für javascript\n"
 "- viele Fehlerbereinigungen.\n"
 "\n"
 "Eine vollständige Liste der neuen Funktionen und Fehlerbereinigungen findet "
@@ -3083,7 +3081,7 @@ msgstr ""
 "- neu: Option buflist.format.name\n"
 "- neu: Variablen ${format_name}, ${current_buffer} und ${merged} für "
 "buflist\n"
-"- ein Hinweis wird angezeigt wenn buflist und Skript buffers.pl installiert "
+"- ein Hinweis wird angezeigt wenn buflist und Skript-buffers.pl installiert "
 "sind\n"
 "- neu: Server/Channel Pointer in trigger IRC Callbacks\n"
 "- neu: API Funktion config_option_get_string und hdata_compare\n"
@@ -3163,7 +3161,7 @@ msgstr ""
 "\n"
 "- neu: \"fset\" Erweiterung (schnelles Verändern von WeeChat und "
 "Erweiterungsoptionen)\n"
-"- neu: \"php\" Erweiterung (Unterstützung von PHP Skripten)\n"
+"- neu: \"php\" Erweiterung (Unterstützung von PHP-Skripten)\n"
 "- neu: Option buflist.look.add_newline\n"
 "- neu: zwei zusätzliche Bar-Items \"buflist2\" und \"buflist3\", welche das "
 "gleiche Format für die Konfigurationsoptionen nutzen\n"
@@ -3256,8 +3254,8 @@ msgstr ""
 "- neu: IRC Server Option \"split_msg_max_length\"\n"
 "- neu: Option logger.file.fsync\n"
 "- neu: Option logger.look.backlog_conditions\n"
-"- neu: Konfigurationsdatei für Skriptenerweiterungen (\"python.conf\", "
-"\"perl.conf\", ...)\n"
+"- neu: Konfigurationsdatei für Skripterweiterungen (\"python.conf\", \"perl."
+"conf\", ...)\n"
 "- neu: \"eval\" Option in Skriptenbefehlen sowie Info \"xxx_eval\" (python, "
 "perl, ruby, lua und guile)\n"
 "- neu: Informationen \"xxx_interpreter\" und \"xxx_version\" in "
@@ -3311,7 +3309,7 @@ msgstr ""
 "smart_filter_chghost und irc.color.message_chghost\n"
 "- neu: Option xfer.network.send_ack\n"
 "- neu: Unterstützung von Python 3.7\n"
-"- Speicherlecks in Skriptenerweiterungen behoben\n"
+"- Speicherlecks in Skripterweiterungen behoben\n"
 "- viele Fehlerbereinigungen\n"
 "\n"
 "Eine vollständige Liste der neuen Funktionen und Fehlerbereinigungen findet "
@@ -3733,7 +3731,7 @@ msgstr ""
 "- IRC Client,\n"
 "- mehreren Benutzeroberflächen: Text, ncurses und Gtk,\n"
 "- auf mehreren Plattformen lauffähig,\n"
-"- schnell, schlank und erweiterbar durch Skripten.\n"
+"- schnell, schlank und erweiterbar durch Skripte.\n"
 "- ..."
 
 #: news/_i18n_info.py:142
@@ -3778,7 +3776,7 @@ msgstr "WeeChat Screenshot"
 
 #: news/_i18n_info.py:146
 msgid "WeeChat scripts page"
-msgstr "WeeChat Skriptenseite"
+msgstr "WeeChat-Skriptseite"
 
 #: news/_i18n_info.py:147
 msgid ""
@@ -3789,11 +3787,11 @@ msgid ""
 "Note: Perl scripts require version of WeeChat > 0.0.3, so today you must "
 "download development version."
 msgstr ""
-"WeeChat Skripten Seite (zur Zeit nur Perl-Skripten) hinzugefügt.\n"
-"Auf dieser Seite können Sie Ihren Skripten einreichen (diese müssen vom "
-"WeeChat Entwicklerteam freigegeben werden).\n"
+"WeeChat-Skriptseite (zur Zeit nur Perl-Skripten) hinzugefügt.\n"
+"Auf dieser Seite können Sie Ihre Skripte einreichen (diese müssen vom "
+"WeeChat-Entwicklerteam freigegeben werden).\n"
 "\n"
-"Hinweis: Perl-Skripten benötigen mindestens Version > 0.0.3 von WeeChat. Zur "
+"Hinweis: Perl-Skripte benötigen mindestens Version > 0.0.3 von WeeChat. Zur "
 "Zeit muss somit die Entwicklerversion genutzt werden."
 
 #: news/_i18n_info.py:148
@@ -3884,7 +3882,7 @@ msgstr "ein einfacher Buffer für URLs."
 #. Translators: description for script "lnotify.py" (0.3.0+)
 #: scripts/_i18n_scripts.py:15
 msgid "A libnotify script."
-msgstr "ein libnotify Skript."
+msgstr "ein libnotify-Skript."
 
 #. Translators: description for script "sshnotify.py" (0.3.0+)
 #: scripts/_i18n_scripts.py:17
@@ -4427,7 +4425,7 @@ msgstr ""
 #: scripts/_i18n_scripts.py:205
 msgid "Debugging tool for python scripts or test WeeChat's API functions."
 msgstr ""
-"Debugtool für Python-Skripten oder um die API Funktionen von WeeChat zu "
+"Debugtool für Python-Skripte oder um die API-Funktionen von WeeChat zu "
 "testen."
 
 #. Translators: description for script "dellog.pl" (0.3.2+)
@@ -4454,7 +4452,7 @@ msgstr "zeigt den Umrechnungswert für Bitcoin oder andere Krypto-Währungen an.
 #. Translators: description for script "infos.py" (0.3.0+)
 #: scripts/_i18n_scripts.py:215
 msgid "Display WeeChats infos, useful for script developers."
-msgstr "zeigt Informationen zu WeeChat an, sinnvoll für Skripten-Entwickler."
+msgstr "zeigt Informationen zu WeeChat an, sinnvoll für Skriptentwickler."
 
 #. Translators: description for script "hilites.rb" (0.3.0+)
 #: scripts/_i18n_scripts.py:217
@@ -4507,7 +4505,7 @@ msgstr ""
 msgid "Display infolist in a buffer, useful for script developers."
 msgstr ""
 "in einem separaten Buffer wird eine Infolisten angezeigt (sinnvoll für "
-"Skripten-Entwickler!)."
+"Skriptentwickler!)."
 
 #. Translators: description for script "kernel.pl" (0.3.0+)
 #: scripts/_i18n_scripts.py:235
@@ -4747,7 +4745,7 @@ msgstr "Channels werden, bei jeder Nachricht, auf highlight gesetzt."
 msgid ""
 "Highly configurable send-notify script for user, channel and server messages."
 msgstr ""
-"sehr konfigurierbares \"verschicke Benachrichtigung\" Skript für User-, "
+"sehr konfigurierbares \"verschicke Benachrichtigung\"-Skript für User-, "
 "Channel- und Servernachrichten."
 
 #. Translators: description for script "giphy.py" (0.3.0+)
@@ -5327,7 +5325,7 @@ msgstr "speichert den aktuellen Buffer-Inhalt in eine Datei."
 #: scripts/_i18n_scripts.py:519
 msgid "Scripts manager."
 msgstr ""
-"Skripten-Manager. Zum einfachen (de-)installieren und aktualisieren von "
+"Skriptmanager. Zum einfachen (De-) Installieren und Aktualisieren von "
 "Skripten von der WeeChat-Homepage."
 
 #. Translators: description for script "win_scroll_screen.py" (0.3.0+)
@@ -5885,7 +5883,7 @@ msgstr ""
 
 #: scripts/models.py:153
 msgid "Popular script"
-msgstr "Skript wird empfohlen"
+msgstr "beliebtes Skript"
 
 #: scripts/models.py:237
 msgid "This name is invalid."
@@ -5910,7 +5908,7 @@ msgstr "Name"
 
 #: scripts/models.py:293
 msgid "The version of script (only digits or dots)."
-msgstr "Version des Skripts (nur Ziffern oder Punkte)."
+msgstr "Version des Skriptes (nur Ziffern oder Punkte)."
 
 #: scripts/models.py:298 templates/scripts/list.html:90
 #: templates/scripts/list.html:92 templates/scripts/pending.html:34
@@ -5990,7 +5988,7 @@ msgid ""
 "The short name of script (max {max_chars} chars, only lower case letters, "
 "digits or \"_\")."
 msgstr ""
-"Kurzname des Skripts (maximal {max_chars} Zeichen und nur Kleinbuchstaben, "
+"Kurzname des Skriptes (maximal {max_chars} Zeichen und nur Kleinbuchstaben, "
 "Ziffern oder \"_\")."
 
 #: scripts/models.py:357 themes/models.py:242
@@ -6147,8 +6145,7 @@ msgstr ""
 #: templates/about/features.html:30
 msgid "<strong>an active project</strong> with a large community for scripts"
 msgstr ""
-"<strong>ein aktives Projekt</strong>, mit einer großen Skripten-"
-"Anhängerschaft"
+"<strong>ein aktives Projekt</strong>, mit einer großen Community für Skripte"
 
 #: templates/about/features.html:40
 msgid "Light and extensible"
@@ -6166,8 +6163,8 @@ msgstr ""
 #: templates/about/features.html:43
 msgid "Plugins and scripts can be dynamically loaded and unloaded at any time."
 msgstr ""
-"Erweiterungen und Skripten können, während der Benutzung, geladen und "
-"entfernt werden."
+"Erweiterungen und Skripte können während der Benutzung geladen und entfernt "
+"werden."
 
 #: templates/about/features.html:46
 msgid "Almost everything is a plugin, for example:"
@@ -6187,7 +6184,7 @@ msgstr "IRC Proxy und Remote-Oberfläche"
 
 #: templates/about/features.html:51 templates/about/features.html:84
 msgid "Scripts manager"
-msgstr "Skripten-Manager"
+msgstr "Skriptmanager"
 
 #: templates/about/features.html:52
 msgid "Alias, aspell, charset, logger, etc."
@@ -6379,7 +6376,7 @@ msgid ""
 "guide and <strong>plugin API</strong> reference."
 msgstr ""
 "Du möchtest für WeeChat ein Skript schreiben? Siehe Dir dazu die "
-"<strong>Skript-</strong> und die Anleitung für die <strong>API Erweiterung</"
+"<strong>Skript-</strong> und die Anleitung für die <strong>API-Erweiterung</"
 "strong> an."
 
 #: templates/about/features.html:156
@@ -6435,7 +6432,7 @@ msgstr "echte Nicklist"
 
 #: templates/about/history.html:26
 msgid "extensible with scripts written in various languages"
-msgstr "erweiterbar durch Skripten für verschiedenen Sprachen"
+msgstr "erweiterbar durch Skripte für verschiedenen Sprachen"
 
 #: templates/about/history.html:28
 msgid "My search was unsuccessful!"
@@ -6562,7 +6559,7 @@ msgid ""
 "Bugs and feature requests for WeeChat, QWeeChat and scripts can be submitted "
 "on GitHub:"
 msgstr ""
-"Fehlermeldungen und Funktionswünsche für WeeChat, QWeeChat und Skripten "
+"Fehlermeldungen und Funktionswünsche für WeeChat, QWeeChat und Skripte "
 "können auf GitHub mitgeteilt werden:"
 
 #: templates/about/support.html:48
@@ -6662,7 +6659,7 @@ msgstr "Download"
 #: templates/home/home.html:66 templates/scripts/python3.html:131
 #: templates/scripts/scripts.html:11
 msgid "Scripts"
-msgstr "Skripten"
+msgstr "Skripte"
 
 #: templates/base.html:39 templates/base.html:132 templates/doc/doc.html:12
 #: templates/download/download.html:12
@@ -6712,7 +6709,7 @@ msgstr "Debian/Ubuntu Repositorien"
 
 #: templates/base.html:112
 msgid "Browse scripts"
-msgstr "Skripten durchstöbern"
+msgstr "Skripte durchstöbern"
 
 #: templates/base.html:113 templates/scripts/scripts.html:12
 msgid "Add script"
@@ -6724,11 +6721,11 @@ msgstr "aktualisiere Skript"
 
 #: templates/base.html:115 templates/scripts/scripts.html:14
 msgid "Pending scripts"
-msgstr "eingereichte Skripten"
+msgstr "eingereichte Skripte"
 
 #: templates/base.html:116 templates/scripts/scripts.html:15
 msgid "Unofficial scripts"
-msgstr "nicht veröffentlichte Skripten"
+msgstr "Inoffizielle Skripte"
 
 #: templates/base.html:133 templates/dev/dev.html:11
 msgid "Roadmap"
@@ -7288,8 +7285,8 @@ msgid ""
 "are python and perl)."
 msgstr ""
 "Binärpakete installieren; das Paket \"plugins\" wird ausdrücklich empfohlen, "
-"ist aber nicht zwingend notwendig. Skripten API-Pakete sind optional "
-"(populäre Sprachen sind python und perl)."
+"ist aber nicht zwingend notwendig. Skript-API-Pakete sind optional (populäre "
+"Sprachen sind python und perl)."
 
 #: templates/download/debian.html:113
 msgid "Example for the stable version:"
@@ -7539,7 +7536,7 @@ msgstr ""
 #: templates/home/home.html:63
 msgid "8 scripting languages supported with a built-in scripts manager."
 msgstr ""
-"8 Skriptsprachen werden unterstützt mit einem eingebauten Skriptenmanager."
+"8 Skriptsprachen werden unterstützt mit einem eingebauten Skriptmanager."
 
 #: templates/home/home.html:79
 msgid "Remote interfaces."
@@ -7733,7 +7730,7 @@ msgid ""
 "the Python scripts must be compatible with Python 3.x, support of Python 2.x "
 "is now optional"
 msgstr ""
-"Python-Skripten müssen Python 3.x unterstützen. Eine zusätzliche "
+"Python-Skripte müssen Python 3.x unterstützen. Eine zusätzliche "
 "Unterstützung von Python 2.x ist freiwillig"
 
 #: templates/scripts/add.html:33
@@ -7775,7 +7772,7 @@ msgid ""
 "months if many scripts are pending)."
 msgstr ""
 "Dein eingereichtes Skript wird überprüft. Die Bearbeitung kann einige Wochen "
-"Zeit beanspruchen (falls mehrere neue Skripten ausstehen, kann es auch ein "
+"Zeit beanspruchen (falls mehrere neue Skripte ausstehen, kann es auch ein "
 "paar Monate dauern)."
 
 #: templates/scripts/add_ok.html:14
@@ -7793,10 +7790,10 @@ msgid ""
 "contributors, therefore WeeChat developers are <strong>NOT RESPONSIBLE</"
 "strong> for problems caused by one of these scripts."
 msgstr ""
-"<strong>Wichtig:</strong> Die Skripten auf dieser Seite werden überwiegend "
+"<strong>Wichtig:</strong> Die Skripte auf dieser Seite werden überwiegend "
 "durch Drittentwicklern bereitgestellt. Aus diesem Grund sind die WeeChat "
 "Autoren <strong>NICHT VERANTWORTLICH</strong> falls Probleme durch diese "
-"Skripten auftreten sollten."
+"Skripte auftreten sollten."
 
 #: templates/scripts/list.html:18
 msgid ""
@@ -7827,7 +7824,7 @@ msgstr "kein Filter"
 
 #: templates/scripts/list.html:33 templates/scripts/scripts.html:5
 msgid "scripts"
-msgstr "Skripten"
+msgstr "Skripte"
 
 #: templates/scripts/list.html:36 templates/scripts/list.html:40
 msgid "Filters by popularity"
@@ -7908,8 +7905,7 @@ msgstr "Kein Skript gefunden."
 
 #: templates/scripts/pending.html:12
 msgid "Following scripts are waiting for approval, possible future is:"
-msgstr ""
-"Folgende Skripten warten auf eine Freigabe. Die weitere Vorgehensweise:"
+msgstr "Folgende Skripte warten auf eine Freigabe. Die weitere Vorgehensweise:"
 
 #: templates/scripts/pending.html:14
 msgid "if script is OK, it is moved to official scripts and git repository."
@@ -7921,8 +7917,8 @@ msgstr ""
 msgid ""
 "if script does not meet all requirements, it is moved to unofficial scripts."
 msgstr ""
-"entspricht ein Skript nicht den Anforderungen, dann wird es zu den nicht "
-"veröffentlichten Skripten verschoben."
+"entspricht ein Skript nicht den Anforderungen, dann wird es zu den "
+"inoffiziellen Skripten verschoben."
 
 #: templates/scripts/pending.html:16
 msgid "if script is rejected, it is deleted."
@@ -7937,7 +7933,7 @@ msgid ""
 "You can help us by testing these scripts. Please report bugs to author of "
 "script and to"
 msgstr ""
-"Du kannst uns helfen indem Du die Skripten testest. Sollten dabei Fehler "
+"Du kannst uns helfen, indem Du die Skripte testest. Sollten dabei Fehler "
 "auftreten informiere Bitte den Autor des Skriptes und"
 
 #: templates/scripts/pending.html:31
@@ -8011,8 +8007,8 @@ msgid ""
 "with Python 2.7."
 msgstr ""
 "Zum aktuellen Zeitpunkt, %(date)s, wird empfohlen WeeChat mit Python 2.7 zu "
-"kompilieren, da viele Skripten nicht mit Python 3.x funktionieren, wobei "
-"alle Skripten unter Python 2.7 lauffähig sein sollten."
+"kompilieren, da viele Skripte nicht mit Python 3.x funktionieren, wobei alle "
+"Skripte unter Python 2.7 lauffähig sein sollten."
 
 #: templates/scripts/python3.html:45
 msgid ""
@@ -8043,14 +8039,14 @@ msgid ""
 "All scripts that are not yet compatible with both Python 2.7 and Python 3.x "
 "can be updated to support both versions (see the status below)."
 msgstr ""
-"Alle Skripten die zur Zeit noch nicht mit Python 2.7 und Python 3.x "
-"kompatibel sind sollten aktualisiert werden um beide Versionen zu "
+"Alle Skripte, die zur Zeit noch nicht mit Python 2.7 und Python 3.x "
+"kompatibel sind, sollten aktualisiert werden, um beide Versionen zu "
 "unterstützen (siehe Status weiter unten)."
 
 #: templates/scripts/python3.html:62
 msgid "You can help by converting existing scripts (see how to help below)."
 msgstr ""
-"Du kannst bei der Konvertierung der Skripten gerne helfen (wie Du helfen "
+"Du kannst bei der Konvertierung der Skripte gerne helfen (wie Du helfen "
 "kannst, steht weiter unten)."
 
 #: templates/scripts/python3.html:68
@@ -8058,7 +8054,7 @@ msgid ""
 "An e-mail is sent to the authors of Python scripts which are not compatible "
 "with Python 3 (at least they are not marked as compatible in database)."
 msgstr ""
-"Eine e-mail wurde an die Autoren von Python-Skripten versendet, welche noch "
+"Eine e-Mail wurde an die Autoren von Python-Skripten versendet, welche noch "
 "nicht kompatibel mit Python 3 sind (oder noch nicht in der Datenbank als "
 "kompatibel aufgeführt werden)."
 
@@ -8067,27 +8063,27 @@ msgid ""
 "All authors are encouraged to make their scripts compatible with Python 3.x "
 "as soon as possible. Help from other people is welcome as well."
 msgstr ""
-"Alle Autoren werden angehalten ihre Skripten so zu erstellen, das diese "
+"Alle Autoren werden angehalten ihre Skripte so zu erstellen, dass diese "
 "baldmöglichst zu Python 3.x kompatibel sind. Unterstützen durch Dritte wird "
 "natürlich gerne angenommen."
 
 #: templates/scripts/python3.html:76
 msgid "All new scripts must be compatible with both Python 2.7 and Python 3.x."
 msgstr ""
-"Alle neuen Skripten müssen sowohl mit Python 2.7 als auch mit Python 3.x "
+"Alle neuen Skripte müssen sowohl mit Python 2.7 als auch mit Python 3.x "
 "kompatibel sein."
 
 #: templates/scripts/python3.html:78
 msgid "Script updates are still allowed to be compatible with Python 2.7 only."
 msgstr ""
-"Skripten die aktualisiert werden brauchen nur Python 2.7 zu unterstützen."
+"Skripte, die aktualisiert werden, brauchen nur Python 2.7 zu unterstützen."
 
 #: templates/scripts/python3.html:84
 msgid ""
 "All new scripts as well as script updates must be compatible with both "
 "Python 2.7 and Python 3.x."
 msgstr ""
-"Alle neuen Skripten sowie alle Skripten die aktualisiert werden, müssen mit "
+"Alle neuen Skripte sowie alle Skripte, die aktualisiert werden, müssen mit "
 "Python 2.7 und Python 3.x kompatibel sein."
 
 #: templates/scripts/python3.html:86
@@ -8095,8 +8091,8 @@ msgid ""
 "Scripts must be properly tested with Python 2.7 and a Python 3.x version (if "
 "possible the latest stable)."
 msgstr ""
-"Skripten müssen gründlich mit Python 2.7 und Python 3.x getestet werden "
-"(wenn möglich mit der aktuellen stabilen Version)."
+"Skripte müssen gründlich mit Python 2.7 und Python 3.x getestet werden (wenn "
+"möglich mit der aktuellen stabilen Version)."
 
 #: templates/scripts/python3.html:92
 msgid ""
@@ -8112,7 +8108,7 @@ msgid ""
 "Python 2.7 and Python 3.x, time for the users to upgrade to the latest "
 "version of WeeChat which is Python 3 only."
 msgstr ""
-"Alle neuen Skripten sowie alle Skripten die aktualisiert werden, müssen "
+"Alle neuen Skripte sowie alle Skripte, die aktualisiert werden, müssen "
 "Python 2.7 und Python 3.x unterstützen. Es wird Zeit das die Anwender auf "
 "die aktuelle Version von WeeChat upgraden, die dann nur noch Python 3 "
 "unterstützt."
@@ -8126,7 +8122,7 @@ msgid ""
 msgstr ""
 "Bedauerlicherweise sind zu diesem Stichtag nur 42%% (96 von 226) der Python-"
 "Skripten mit Python3 kompatibel. Standardmäßig wird WeeChat nun mit Python 3 "
-"kompiliert was hoffentlich dazu führt, dass die verbleibenden Skripten "
+"kompiliert was hoffentlich dazu führt, dass die verbleibenden Skripte "
 "zeitnah angepasst werden."
 
 #: templates/scripts/python3.html:102
@@ -8148,14 +8144,14 @@ msgid ""
 "All new scripts as well as script updates must be compatible with Python 3."
 "x. Extra support of Python 2.x is optional."
 msgstr ""
-"Alle neuen Skripten sowie alle Skripten die aktualisiert werden, müssen "
+"Alle neuen Skripte sowie alle Skripte, die aktualisiert werden, müssen "
 "Python 3.x unterstützen. Eine zusätzliche Unterstützung von Python 2.x ist "
 "freiwillig."
 
 #: templates/scripts/python3.html:112
 msgid ""
 "Hopefully, at this date, all scripts should be compatible with Python 3."
-msgstr "Hoffentlich unterstützen an diesem Tag alle Skripten Python 3."
+msgstr "Hoffentlich unterstützen an diesem Tag alle Skripte Python 3."
 
 #: templates/scripts/python3.html:114
 msgid ""
@@ -8164,8 +8160,8 @@ msgid ""
 "page, but marked as \"disabled\" and these scripts can not be installed in "
 "WeeChat."
 msgstr ""
-"<strong>Wichtig</strong>: Skripten die an diesem Tag noch nicht mit Python 3 "
-"kompatibel sind werden deaktiviert: Diese Skripten werden auf der "
+"<strong>Wichtig</strong>: Skripte, die an diesem Tag noch nicht mit Python 3 "
+"kompatibel sind, werden deaktiviert: Diese Skripte werden auf der "
 "Skriptseite aufgeführt, haben aber den Vermerk \"deaktiviert\" und können "
 "nicht in WeeChat installiert werden."
 
@@ -8174,12 +8170,8 @@ msgid "Transition status"
 msgstr "Status der Umstellung"
 
 #: templates/scripts/python3.html:122
-#, fuzzy
-#| msgid ""
-#| "The scripts which are compatible with Python 3 have tag \"py3k-ok\"</a>."
 msgid "The scripts which are compatible with Python 3 have tag \"py3\"</a>."
-msgstr ""
-"Skripten die Python 3 kompatibel sind, erhalten das Tag \"py3k-ok\"</a>."
+msgstr "Skripte, die Python 3 kompatibel sind, erhalten das Tag \"py3\"</a>."
 
 #: templates/scripts/python3.html:124
 msgid "Transition status at various dates:"
@@ -8187,7 +8179,7 @@ msgstr "Status der Umstellung zu verschiedenen Zeitpunkten:"
 
 #: templates/scripts/python3.html:132
 msgid "Python scripts"
-msgstr "Python Skripten"
+msgstr "Python-Skripte"
 
 #. Translators: use plural form for "compatible", if needed
 #: templates/scripts/python3.html:135
@@ -8277,7 +8269,7 @@ msgstr "Um zwischen den Python-Versionen zu wechseln, /py2 oder /py3 eingeben."
 #: templates/scripts/python3.html:273
 msgid "Note: this unloads all scripts because the Python plugin is reloaded."
 msgstr ""
-"Hinweis: dies schließt alle Skripten, das die Python-Erweiterung neu geladen "
+"Hinweis: dies schließt alle Skripte, da die Python-Erweiterung neu geladen "
 "wird."
 
 #: templates/scripts/python3.html:277
@@ -8322,9 +8314,9 @@ msgid ""
 "could comment them before they are merged in the repository. If this is not "
 "possible, then you can use this form."
 msgstr ""
-"<strong>Wichtig:</strong> die empfohlene  Vorgehensweise um ein Skript "
-"upzudaten  ist ein Pull Request auf <a href=\"https://github.com/weechat/"
-"scripts/\">Github Skript Repositorium</a>: die Veränderungen werden "
+"<strong>Wichtig:</strong> die empfohlene Vorgehensweise um ein Skript "
+"upzudaten ist ein Pull Request auf <a href=\"https://github.com/weechat/"
+"scripts/\">Github Skript-Repositorium</a>: die Veränderungen werden "
 "veröffentlicht und andere können die Änderungen kommentieren, bevor es in "
 "das Repositorium übernommen wird. Sollte das nicht möglich sein, kann das "
 "Formular auf dieser Seite verwendet werden."


### PR DESCRIPTION
Fix the German translation of “scripts” in all variants but mostly the
plural form which is “Skripte” and not “Skripten”.