### PR TITLE
Update Raspbian instructions

### DIFF
--- a/weechat/templates/download/debian.html
+++ b/weechat/templates/download/debian.html
@@ -60,7 +60,7 @@ var deb_apt_cmds = [
 <h4>{% trans "GPG key" %}</h4>
 
 <p>
-  {% trans "Import the GPG key used to sign the repositories (except the Raspbian repositories, which are NOT signed):" %}
+  {% trans "Import the GPG key used to sign the repositories:" %}
   <pre><code>$ sudo apt-key adv --keyserver hkps://keys.openpgp.org --recv-keys 11E9DE8848F2B65222AA75B8D1820DB22A11534E</code></pre>
 </p>
 


### PR DESCRIPTION
Previously it was mentioned that Raspbian users didn't need to import GPG keys, but it seems that this is no longer true (I just tested).