### PR TITLE
Do no longer use apt-key

### DIFF
--- a/weechat/debian/models.py
+++ b/weechat/debian/models.py
@@ -76,20 +76,20 @@ class Repo(models.Model):
     def apt_url(self):
         """
         Return the URL to use with apt for binary packages, for example:
-        "deb [signed-by=/usr/share/keyrings/weechat-archive-keyring.gpg]
+        "deb [signed-by=/usr/local/share/keyrings/weechat-archive-keyring.gpg]
         https://weechat.org/debian sid main".
         """
-        return (f'deb [signed-by=/usr/share/keyrings/weechat-archive-keyring.gpg]'
-                f'{self.url} {self.version.codename} main')
+        return (f'deb [signed-by=/usr/local/share/keyrings/weechat-archive-'
+                f'keyring.gpg] {self.url} {self.version.codename} main')
 
     def apt_url_src(self):
         """
         Return the URL to use with apt for sources packages, for example:
-        "deb-src [signed-by=/usr/share/keyrings/weechat-archive-keyring.gpg]
-        https://weechat.org/debian sid main".
+        "deb-src [signed-by=/usr/local/share/keyrings/weechat-archive-
+        keyring.gpg] https://weechat.org/debian sid main".
         """
-        return (f'deb-src [signed-by=/usr/share/keyrings/weechat-archive-keyring.gpg]'
-                f'{self.url} {self.version.codename} main')
+        return (f'deb-src [signed-by=/usr/local/share/keyrings/weechat-archive-'
+                f'keyring.gpg] {self.url} {self.version.codename} main')
 
     class Meta:
         """Sort Repos by priority."""

--- a/weechat/templates/download/debian.html
+++ b/weechat/templates/download/debian.html
@@ -61,7 +61,7 @@ var deb_apt_cmds = [
 
 <p>
   {% trans "Import the GPG key used to sign the repositories:" %}
-  <pre><code>$ sudo gpg --no-default-keyring --keyring /usr/share/keyrings/weechat-archive-keyring.gpg --keyserver hkps://keys.openpgp.org --recv-keys 11E9DE8848F2B65222AA75B8D1820DB22A11534E</code></pre>
+  <pre><code>$ sudo gpg --no-default-keyring --keyring /usr/local/share/keyrings/weechat-archive-keyring.gpg --keyserver hkps://keys.openpgp.org --recv-keys 11E9DE8848F2B65222AA75B8D1820DB22A11534E</code></pre>
 </p>
 
 <p>


### PR DESCRIPTION
Apt-key is deprecated and no longer available in Debian 11 and Ubuntu 22.04. This PR removes apt-key from installation instruction.